### PR TITLE
Add the babelify transform so this app will work on IE

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,6 +1,7 @@
 var gulp = require('gulp')
 var _ = require('underscore')
 var browserify = require('browserify')
+var babelify = require('babelify')
 var watchify = require('watchify')
 var source = require('vinyl-source-stream')
 var buffer = require('vinyl-buffer')
@@ -73,6 +74,7 @@ function scripts (src, dest, watch) {
   if (watch) bundleOpts.debug = true
 
   var bundle = browserify(src, bundleOpts)
+  bundle.transform(babelify)
 
   if (watch) {
     bundle = watchify(bundle)

--- a/package.json
+++ b/package.json
@@ -20,6 +20,9 @@
   "license": "GPL-2.0",
   "dependencies": {
     "amcharts3": "amcharts/amcharts3",
+    "babel-polyfill": "^6.23.0",
+    "babel-preset-latest": "^6.24.0",
+    "babelify": "^7.3.0",
     "backbone": "^1.2.2",
     "backbone.modal": "github:jimf/backbone.modal#npm-remove-engines",
     "bluebird": "^3.1.1",

--- a/src/scripts/vizwit-onpage.js
+++ b/src/scripts/vizwit-onpage.js
@@ -1,4 +1,4 @@
-require("babel-polyfill")
+require('babel-polyfill')
 var $ = require('jquery')
 var _ = require('underscore')
 var Backbone = require('backbone')

--- a/src/scripts/vizwit-onpage.js
+++ b/src/scripts/vizwit-onpage.js
@@ -1,3 +1,4 @@
+require("babel-polyfill")
 var $ = require('jquery')
 var _ = require('underscore')
 var Backbone = require('backbone')


### PR DESCRIPTION
Not only do some of the libraries we're using require the Symbol feauture of ES6 but also they are using some ES6 syntax so we need to use babel to compile it down to ES5